### PR TITLE
Adding weaviate 1.29.x patched version that uses RBAC like 1.28.x

### DIFF
--- a/vulnerabilities/AIKIDO-2025-10149.json
+++ b/vulnerabilities/AIKIDO-2025-10149.json
@@ -1,12 +1,17 @@
 {
   "package_name": "github.com/weaviate/weaviate",
   "patch_versions": [
-    "1.28.9"
+    "1.28.9",
+    "1.29.1"
   ],
   "vulnerable_ranges": [
     [
       "1.28.3",
       "1.28.8"
+    ],
+    [
+      "1.29.0",
+      "1.29.0"
     ]
   ],
   "cwe": [


### PR DESCRIPTION
(patched 1.29.x)[https://github.com/weaviate/weaviate/releases/tag/v1.29.1]


@sampion88, we may need to add this patched version here. They released a patch for 1.29.x that wasn't tagged in file researched for this intel vulnerability.
(version 1.29.0)[https://github.com/weaviate/weaviate/releases/tag/v1.29.0]

