### PR TITLE
New Vuln: Auth Bypass in @opennextjs/aws

### DIFF
--- a/input/new.json
+++ b/input/new.json
@@ -8,7 +8,7 @@
     ]
   ],
   "cwe": ["CWE-285"],
-  "tldr": "Affected versions of this package are affected by an Authorization Bypass via internal request spoofing. The middleware bypasses authorization checks for internal requests but fails to adequately validate whether the requests are genuinely internal, enabling attackers to impersonate internal requests and circumvent access controls. An attacker could craft a malicious request with a fake internal flag, gaining unauthorized access to protected routes or critical system functionalities.",
+  "tldr": "Affected versions of this package are vulnerable to an authorization bypass due to improper validation of internal requests. The middleware exempts internal requests from authorization checks but fails to verify their authenticity, allowing attackers to spoof internal requests and bypass access controls. By crafting a request with a forged internal flag, an attacker can gain unauthorized access to protected routes or critical system functionalities.",
   "doest_this_affect_me": "You are affected if you are using a version that falls within the vulnerable range.",
   "how_to_fix": "Upgrade the `@opennextjs/aws` library to the patch version.",
   "vulnerable_to": "Authorization Bypass",

--- a/input/new.json
+++ b/input/new.json
@@ -1,15 +1,20 @@
 {
-  "package_name": "",
-  "patch_versions": [],
-  "vulnerable_ranges": [],
-  "cwe": [],
-  "tldr": "",
-  "doest_this_affect_me": "",
-  "how_to_fix": "",
-  "vulnerable_to": "",
-  "related_cve_id": "",
-  "language": "",
-  "severity_class": "",
-  "aikido_score": 0,
-  "changelog": ""
+  "package_name": "@opennextjs/aws",
+  "patch_versions": ["3.5.4"],
+  "vulnerable_ranges": [
+    [
+      "2.3.0",
+      "3.5.3"
+    ]
+  ],
+  "cwe": ["CWE-285"],
+  "tldr": "Affected versions of this package are affected by an Authorization Bypass via internal request spoofing. The middleware bypasses authorization checks for internal requests but fails to adequately validate whether the requests are genuinely internal, enabling attackers to impersonate internal requests and circumvent access controls. An attacker could craft a malicious request with a fake internal flag, gaining unauthorized access to protected routes or critical system functionalities.",
+  "doest_this_affect_me": "You are affected if you are using a version that falls within the vulnerable range.",
+  "how_to_fix": "Upgrade the `@opennextjs/aws` library to the patch version.",
+  "vulnerable_to": "Authorization Bypass",
+  "related_cve_id": "CVE-2025-29927",
+  "language": "JS",
+  "severity_class": "CRITICAL",
+  "aikido_score": 91,
+  "changelog": "https://github.com/opennextjs/opennextjs-aws/releases/tag/v3.5.4"
 }

--- a/input/new.json
+++ b/input/new.json
@@ -1,20 +1,15 @@
 {
-  "package_name": "@opennextjs/aws",
-  "patch_versions": ["3.5.4"],
-  "vulnerable_ranges": [
-    [
-      "2.3.0",
-      "3.5.3"
-    ]
-  ],
-  "cwe": ["CWE-285"],
-  "tldr": "Affected versions of this package are vulnerable to an authorization bypass due to improper validation of internal requests. The middleware exempts internal requests from authorization checks but fails to verify their authenticity, allowing attackers to spoof internal requests and bypass access controls. By crafting a request with a forged internal flag, an attacker can gain unauthorized access to protected routes or critical system functionalities.",
-  "doest_this_affect_me": "You are affected if you are using a version that falls within the vulnerable range.",
-  "how_to_fix": "Upgrade the `@opennextjs/aws` library to the patch version.",
-  "vulnerable_to": "Authorization Bypass",
-  "related_cve_id": "CVE-2025-29927",
-  "language": "JS",
-  "severity_class": "CRITICAL",
-  "aikido_score": 91,
-  "changelog": "https://github.com/opennextjs/opennextjs-aws/releases/tag/v3.5.4"
+  "package_name": "",
+  "patch_versions": [],
+  "vulnerable_ranges": [],
+  "cwe": [],
+  "tldr": "",
+  "doest_this_affect_me": "",
+  "how_to_fix": "",
+  "vulnerable_to": "",
+  "related_cve_id": "",
+  "language": "",
+  "severity_class": "",
+  "aikido_score": 0,
+  "changelog": ""
 }

--- a/vulnerabilities/AIKIDO-2025-10204.json
+++ b/vulnerabilities/AIKIDO-2025-10204.json
@@ -1,0 +1,26 @@
+{
+  "package_name": "@opennextjs/aws",
+  "patch_versions": [
+    "3.5.4"
+  ],
+  "vulnerable_ranges": [
+    [
+      "2.3.0",
+      "3.5.3"
+    ]
+  ],
+  "cwe": [
+    "CWE-285"
+  ],
+  "tldr": "Affected versions of this package are vulnerable to an authorization bypass due to improper validation of internal requests. The middleware exempts internal requests from authorization checks but fails to verify their authenticity, allowing attackers to spoof internal requests and bypass access controls. By crafting a request with a forged internal flag, an attacker can gain unauthorized access to protected routes or critical system functionalities.",
+  "doest_this_affect_me": "You are affected if you are using a version that falls within the vulnerable range.",
+  "how_to_fix": "Upgrade the `@opennextjs/aws` library to the patch version.",
+  "vulnerable_to": "Authorization Bypass",
+  "related_cve_id": "CVE-2025-29927",
+  "language": "JS",
+  "severity_class": "CRITICAL",
+  "aikido_score": 91,
+  "changelog": "https://github.com/opennextjs/opennextjs-aws/releases/tag/v3.5.4",
+  "last_modified": "2025-04-03",
+  "published": "2025-04-03"
+}


### PR DESCRIPTION
This Vuln resembles the vulnerable logic from [NextJS Auth Bypass](https://nvd.nist.gov/vuln/detail/CVE-2025-29927) as it relies only on an existing and non null header to flag the request as internal, allowing any spoofed request with a populated `x-isr` header to bypass middleware validations, almost the same mechanism of `x-middleware-subrequest` header from NextJs.

Kept the same score because of it :) 