### PR TITLE
New vuln: insufficient mail address encoding in wneessen/go-mail

### DIFF
--- a/input/new.json
+++ b/input/new.json
@@ -1,15 +1,24 @@
 {
-  "package_name": "",
-  "patch_versions": [],
-  "vulnerable_ranges": [],
-  "cwe": [],
-  "tldr": "",
-  "doest_this_affect_me": "",
-  "how_to_fix": "",
-  "vulnerable_to": "",
-  "related_cve_id": "",
-  "language": "",
-  "severity_class": "",
-  "aikido_score": 0,
-  "changelog": ""
+  "package_name": "github.com/wneessen/go-mail",
+  "patch_versions": [
+		  "0.7.1"
+  ],
+  "vulnerable_ranges": [
+		  [
+				  "0.1.0",
+				  "0.7.0"
+		  ]
+  ],
+  "cwe": [
+		  "CWE-88"
+  ],
+  "tldr": "Due to incorrect handling of the `mail.Address` values when a sender- or recipient address is passed to the corresponding `MAIL FROM` or `RCPT TO` commands of the SMTP client, this could lead to a possible wrong address routing or even to ESMTP parameter smuggling.",
+  "doest_this_affect_me": "For successful exploitation of this vulnerability it is required that the user's code is allowing for arbitrary mail address input (i. e. through a web form or similar). If only static mail addresses are used (i. e. in a config file) and the mail addresses in use do not consist of quoted local parts, this should not affect your code.",
+  "how_to_fix": "Upgrade the `github.com/wneessen/go-mail` package to the patch version.",
+  "vulnerable_to": "Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')",
+  "related_cve_id": "CVE-2025-59937",
+  "language": "GO",
+  "severity_class": "HIGH",
+  "aikido_score": 82,
+  "changelog": "https://github.com/wneessen/go-mail/releases/tag/v0.7.1"
 }


### PR DESCRIPTION
Adds wneessen/go-mail vuln: https://github.com/wneessen/go-mail/security/advisories/GHSA-wpwj-69cm-q9c5 / CVE-2025-59937