### PR TITLE
New vuln: Missing Auth in DNN Core

### DIFF
--- a/input/new.json
+++ b/input/new.json
@@ -1,24 +1,15 @@
 {
-  "package_name": "DotNetNuke.Instrumentation",
-  "patch_versions": [
-    "10.1.1"
-  ],
-  "vulnerable_ranges": [
-    [
-      "5.0.0",
-      "10.1.0"
-    ]
-  ],
-  "cwe": [
-    "CWE-862"
-  ],
-  "tldr": "Affected versions of this package are vulnerable to an unauthenticated file upload issue in CKEditor. This vulnerability allows anonymous users to upload files through CKEditor endpoints, which should be restricted to authenticated users as a security measure. An attacker could exploit this weakness by uploading malicious files, such as scripts or executable content. It could potentially result in remote code execution, site defacement, or unauthorized data manipulation.",
-  "doest_this_affect_me": "You are affected if you are using a version that falls within the vulnerable range.",
-  "how_to_fix": "Upgrade the `DotNetNuke.Instrumentation` library to the patch version.",
-  "vulnerable_to": "Missing Authorization",
+  "package_name": "",
+  "patch_versions": [],
+  "vulnerable_ranges": [],
+  "cwe": [],
+  "tldr": "",
+  "doest_this_affect_me": "",
+  "how_to_fix": "",
+  "vulnerable_to": "",
   "related_cve_id": "",
-  "language": "dotnet",
-  "severity_class": "MEDIUM",
-  "aikido_score": 62,
-  "changelog": "https://github.com/dnnsoftware/Dnn.Platform/releases/tag/v10.1.1"
+  "language": "",
+  "severity_class": "",
+  "aikido_score": 0,
+  "changelog": ""
 }

--- a/input/new.json
+++ b/input/new.json
@@ -1,5 +1,5 @@
 {
-  "package_name": "DotNetNuke.Core",
+  "package_name": "DotNetNuke.Instrumentation",
   "patch_versions": [
     "10.1.1"
   ],
@@ -14,7 +14,7 @@
   ],
   "tldr": "Affected versions of this package are vulnerable to an unauthenticated file upload issue in CKEditor. This vulnerability allows anonymous users to upload files through CKEditor endpoints, which should be restricted to authenticated users as a security measure. An attacker could exploit this weakness by uploading malicious files, such as scripts or executable content. It could potentially result in remote code execution, site defacement, or unauthorized data manipulation.",
   "doest_this_affect_me": "You are affected if you are using a version that falls within the vulnerable range.",
-  "how_to_fix": "Upgrade the `DotNetNuke.Core` library to the patch version.",
+  "how_to_fix": "Upgrade the `DotNetNuke.Instrumentation` library to the patch version.",
   "vulnerable_to": "Missing Authorization",
   "related_cve_id": "",
   "language": "dotnet",

--- a/input/new.json
+++ b/input/new.json
@@ -1,15 +1,24 @@
 {
-  "package_name": "",
-  "patch_versions": [],
-  "vulnerable_ranges": [],
-  "cwe": [],
-  "tldr": "",
-  "doest_this_affect_me": "",
-  "how_to_fix": "",
-  "vulnerable_to": "",
+  "package_name": "DotNetNuke.Core",
+  "patch_versions": [
+    "10.1.1"
+  ],
+  "vulnerable_ranges": [
+    [
+      "5.0.0",
+      "10.1.0"
+    ]
+  ],
+  "cwe": [
+    "CWE-862"
+  ],
+  "tldr": "Affected versions of this package are vulnerable to an unauthenticated file upload issue in CKEditor. This vulnerability allows anonymous users to upload files through CKEditor endpoints, which should be restricted to authenticated users as a security measure. An attacker could exploit this weakness by uploading malicious files, such as scripts or executable content. It could potentially result in remote code execution, site defacement, or unauthorized data manipulation.",
+  "doest_this_affect_me": "You are affected if you are using a version that falls within the vulnerable range.",
+  "how_to_fix": "Upgrade the `DotNetNuke.Core` library to the patch version.",
+  "vulnerable_to": "Missing Authorization",
   "related_cve_id": "",
-  "language": "",
-  "severity_class": "",
-  "aikido_score": 0,
-  "changelog": ""
+  "language": "dotnet",
+  "severity_class": "MEDIUM",
+  "aikido_score": 62,
+  "changelog": "https://github.com/dnnsoftware/Dnn.Platform/releases/tag/v10.1.1"
 }

--- a/vulnerabilities/AIKIDO-2025-10681.json
+++ b/vulnerabilities/AIKIDO-2025-10681.json
@@ -1,0 +1,26 @@
+{
+  "package_name": "DotNetNuke.Instrumentation",
+  "patch_versions": [
+    "10.1.1"
+  ],
+  "vulnerable_ranges": [
+    [
+      "5.0.0",
+      "10.1.0"
+    ]
+  ],
+  "cwe": [
+    "CWE-862"
+  ],
+  "tldr": "Affected versions of this package are vulnerable to an unauthenticated file upload issue in CKEditor. This vulnerability allows anonymous users to upload files through CKEditor endpoints, which should be restricted to authenticated users as a security measure. An attacker could exploit this weakness by uploading malicious files, such as scripts or executable content. It could potentially result in remote code execution, site defacement, or unauthorized data manipulation.",
+  "doest_this_affect_me": "You are affected if you are using a version that falls within the vulnerable range.",
+  "how_to_fix": "Upgrade the `DotNetNuke.Instrumentation` library to the patch version.",
+  "vulnerable_to": "Missing Authorization",
+  "related_cve_id": "",
+  "language": "dotnet",
+  "severity_class": "MEDIUM",
+  "aikido_score": 62,
+  "changelog": "https://github.com/dnnsoftware/Dnn.Platform/releases/tag/v10.1.1",
+  "last_modified": "2025-10-08",
+  "published": "2025-10-08"
+}


### PR DESCRIPTION
This one was a bit confusing to detect which package was actually the holder of the misconfiguration, according to the docs DNN Core is the closest I could find.

please, double check it here before merging